### PR TITLE
HIPCMS-575: New topic status + small UI changes

### DIFF
--- a/app/topics/shared/topic.service.ts
+++ b/app/topics/shared/topic.service.ts
@@ -230,11 +230,11 @@ export class TopicService {
   }
 
   /**
-   * Updates a given Status
-   * @param id The Id of the Topic, Status of the topic
-   * @param status the status to change to
+   * Updates status of a given topic.
+   * @param id id of the topic for which to update the status
+   * @param status new status
    */
-  public saveStatusofTopic(id: number, status: string) {
+  public changeStatusOfTopic(id: number, status: string) {
     return this.cmsApiService.putUrl('/api/Topics/' + id + '/Status', JSON.stringify({status: status}), {})
       .toPromise()
       .catch(

--- a/app/topics/show-topic/show-topic.component.css
+++ b/app/topics/show-topic/show-topic.component.css
@@ -22,6 +22,7 @@ h3.md-line {
 
 .title-wrapper {
   display: flex;
+  align-items: center;
   width: 100%;
 }
 

--- a/app/topics/show-topic/show-topic.component.css
+++ b/app/topics/show-topic/show-topic.component.css
@@ -105,21 +105,6 @@ md-list-item p {
   color: #666;
 }
 
-.radio-text {
-  font-size: 14px;
-  font-weight: normal;
-}
-
-.save {
-  font-size: 27px;
-  font-weight: 400;
-  cursor: pointer;
-}
-
-.save:hover {
-  background: white;
-}
-
 md-tab-group {
   max-width: 1024px;
   margin: 10px auto;

--- a/app/topics/show-topic/show-topic.component.html
+++ b/app/topics/show-topic/show-topic.component.html
@@ -6,24 +6,11 @@
         <div class="title-wrapper">
           <div class="title"><h2>{{ topic.title }}</h2></div>
           <div class="status">
+            <span>Status: {{ topic.status | translate }}</span>
             <button *ngIf="userCanEditContent && !userCanEditDetails && topic.status === 'InProgress'"
-                    md-raised-button (click)="saveStudentReviewStatus()" color="primary">
+                    md-raised-button (click)="markTopicForReview()" color="primary">
               {{ "Ready for review" | translate }}
             </button>
-            <span *ngIf="!userCanEditDetails">Status: {{ topic.status | translate}}</span>
-            <span *ngIf="userCanEditDetails">
-          <md-radio-group class="radio-text" (change)="isSaveButtonDisabled = false" [(ngModel)]="topic.status" #status="ngModel"
-                          ngDefaultControl>
-            <md-radio-button value="InProgress">{{ 'InProgress' | translate }}</md-radio-button>
-            <md-radio-button value="InReview">{{ 'InReview' | translate }}</md-radio-button>
-            <md-radio-button value="Done">{{ 'Done' | translate }}</md-radio-button>
-          </md-radio-group>
-        </span>
-            <span>
-          <button md-icon-button [disabled]="isSaveButtonDisabled" (click)="saveStatus()" *ngIf="userCanEditDetails">
-            <md-icon class="save">save</md-icon>
-          </button>
-        </span>
           </div>
         </div>
       </md-card-title>

--- a/app/topics/show-topic/show-topic.component.ts
+++ b/app/topics/show-topic/show-topic.component.ts
@@ -26,7 +26,6 @@ export class ShowTopicComponent implements OnInit, OnDestroy {
   hideSearch = false;
   parentTopicId: number;
   translatedResponse: any;
-  isSaveButtonDisabled = true;
 
   private subscription: Subscription;
   private topicId: number;
@@ -62,19 +61,15 @@ export class ShowTopicComponent implements OnInit, OnDestroy {
       );
   }
 
-  saveStudentReviewStatus() {
+  markTopicForReview() {
     this.topic.status = 'InReview';
-    this.saveStatus();
-  }
-
-  saveStatus() {
-    this.topicService.saveStatusofTopic(this.topic.id, this.topic.status)
+    this.topicService.changeStatusOfTopic(this.topic.id, this.topic.status)
       .then(
-        (response: any) => this.handleResponseStatus(response)
+        response => this.toasterService.pop('success', this.getTranslatedString('Status updated'),
+                                            this.getTranslatedString(this.topic.status))
       ).catch(
         (error: any) => this.handleError(error)
       );
-    this.isSaveButtonDisabled = true;
   }
 
   private reloadTopic() {
@@ -144,10 +139,6 @@ export class ShowTopicComponent implements OnInit, OnDestroy {
           this.toasterService.pop('error', this.getTranslatedString('Error fetching parent topics') , error);
         }
       );
-  }
-
-  private handleResponseStatus(response: any) {
-    this.toasterService.pop('success', 'Success', this.topic.status + ' - ' + this.getTranslatedString('Status updated'));
   }
 
   private handleError(error: string) {

--- a/app/topics/topic-management/topic-input/topic-input.component.css
+++ b/app/topics/topic-management/topic-input/topic-input.component.css
@@ -13,7 +13,8 @@ md-card-title {
   border-bottom: 4px solid #FF8200;
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  align-items: baseline;
   transition: all .4s;
 }
 
@@ -35,12 +36,17 @@ md-card-title {
 
 md-card-title md-input {
   color: #FF8200;
-  flex-grow: 1;
+  flex-grow: 10;
   padding-top: 10px;
 }
 
-md-radio-button {
-  margin-left: 20px;
+md-card-title md-select {
+  flex-grow: 1;
+  position: relative;
+  top: -5px;
+  margin: 0 0 0 25px;
+  font-size: 75%;
+  line-height: normal;
 }
 
 .item-wrapper {
@@ -75,14 +81,6 @@ md-radio-button {
 .column-right {
   flex-wrap: nowrap;
   flex-grow: 1;
-}
-
-md-radio-group {
-  float: right;
-  font-size: .5em;
-  margin-right: 20px;
-  margin-top: 15px;
-  flex-wrap: nowrap;
 }
 
 .label {

--- a/app/topics/topic-management/topic-input/topic-input.component.html
+++ b/app/topics/topic-management/topic-input/topic-input.component.html
@@ -22,12 +22,13 @@
         </li>
       </ul>
     </div>
-    <md-radio-group [(ngModel)]="topic.status" #status="ngModel" ngDefaultControl
-                    (ngModelChange)="modelChanged('status')">
-      <md-radio-button value="InProgress">{{ 'in progress' | translate }}</md-radio-button>
-      <md-radio-button value="InReview">{{ 'in review' | translate }}</md-radio-button>
-      <md-radio-button value="Done">{{ 'done' | translate }}</md-radio-button>
-    </md-radio-group>
+    <md-select [(ngModel)]="topic.status" #status="ngModel" ngDefaultControl placeholder="Status"
+                (ngModelChange)="modelChanged('status')">
+      <md-option value="InProgress">{{ 'InProgress' | translate }}</md-option>
+      <md-option value="InReview">{{ 'InReview' | translate }}</md-option>
+      <md-option value="InProgressAgain">{{ 'InProgressAgain' | translate }}</md-option>
+      <md-option value="Done">{{ 'Done' | translate }}</md-option>
+    </md-select>
   </md-card-title>
   <md-card-content>
     <div class="form-group input-wrapper">

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -99,6 +99,7 @@
   "title required": "Titel erforderlich",
   "InProgress": "In Bearbeitung",
   "InReview": "In Überprüfung",
+  "InProgressAgain": "Erneut in Bearbeitung",
   "Done": "Erledigt",
   "Ready for review": "Bereit zur Überprüfung",
   "todo": "Zu erledigen",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -93,6 +93,7 @@
   "title required": "Title required",
   "InProgress": "In progress",
   "InReview": "In review",
+  "InProgressAgain": "In progress again",
   "Done": "Done",
   "Ready for review": "Ready for review",
   "todo": "Todo",


### PR DESCRIPTION
- Topics have a new status "in progress again"
- Status controls have been removed from "show topic" component, since students don't see them anymore. Topic status is now only shown as plain text, visible to all.
- Status selection has been changed to `<md-select>` instead of radio buttons.
- Fixed small UI bug in which status names weren't shown translated.