### PR TITLE
Update pagination package

### DIFF
--- a/app/core/core.module.ts
+++ b/app/core/core.module.ts
@@ -3,7 +3,7 @@ import { HttpModule } from '@angular/http';
 import { RouterModule } from '@angular/router';
 import { AuthHttp, provideAuth } from 'angular2-jwt';
 import { ToasterModule, ToasterService } from 'angular2-toaster';
-import { Ng2PaginationModule } from 'ng2-pagination';
+import { NgxPaginationModule } from 'ngx-pagination';
 import { TranslateModule, TranslateService } from 'ng2-translate';
 
 import { AdminGuard } from './guards/admin-guard';
@@ -19,7 +19,7 @@ import { UserService } from './user/user.service';
 @NgModule({
   imports: [
     HttpModule,
-    Ng2PaginationModule,
+    NgxPaginationModule,
     RouterModule,
     TranslateModule.forRoot(),
     ToasterModule
@@ -27,7 +27,7 @@ import { UserService } from './user/user.service';
   exports: [
     ToasterModule,
     TranslateModule,
-    Ng2PaginationModule
+    NgxPaginationModule
   ],
   providers: [
     TranslateService,

--- a/app/shared/shared.module.ts
+++ b/app/shared/shared.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MaterialModule } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
-import { Ng2PaginationModule } from 'ng2-pagination';
+import { NgxPaginationModule } from 'ngx-pagination';
 import { TagInputModule } from 'ng2-tag-input';
 import { TranslateModule } from 'ng2-translate';
 
@@ -22,7 +22,7 @@ import { UserTagInputComponent } from './taginput/user-tag-input.component';
     MaterialModule.forRoot(),
     TagInputModule,
     TranslateModule,
-    Ng2PaginationModule,
+    NgxPaginationModule,
     sharedRouting
   ],
   exports: [

--- a/app/topics/topics.module.ts
+++ b/app/topics/topics.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MaterialModule, MdUniqueSelectionDispatcher, OverlayModule } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
-import { Ng2PaginationModule } from 'ng2-pagination';
+import { NgxPaginationModule } from 'ngx-pagination';
 import { TranslateModule } from 'ng2-translate';
 
 import { topicRouting } from './topics.routing';
@@ -35,7 +35,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     BrowserAnimationsModule,
     FormsModule,
     MaterialModule,
-    Ng2PaginationModule,
+    NgxPaginationModule,
     OverlayModule.forRoot(),
     SharedModule,
     ReactiveFormsModule,

--- a/app/users/users.module.ts
+++ b/app/users/users.module.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MaterialModule } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
 import { TagInputModule } from 'ng2-tag-input';
-import { Ng2PaginationModule } from 'ng2-pagination';
+import { NgxPaginationModule } from 'ngx-pagination';
 import { TranslateModule } from 'ng2-translate';
 
 import { usersRouting } from './users.routing';
@@ -22,7 +22,7 @@ import { UsersSorter } from './admin/pipes/sort.pipe';
     BrowserModule,
     FormsModule,
     MaterialModule,
-    Ng2PaginationModule,
+    NgxPaginationModule,
     ReactiveFormsModule,
     SharedModule,
     TagInputModule,

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "hammerjs": "2.0.8",
     "ng2-dragula": "1.3.1",
     "ng2-material-dropdown": "0.7.7",
-    "ng2-pagination": "2.0.1",
     "ng2-tag-input": "1.0.5",
     "ng2-translate": "5.0.0",
+    "ngx-pagination": "3.0.0",
     "rxjs": "5.3.0",
     "systemjs": "0.20.12",
     "zone.js": "0.8.8"

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -16,7 +16,7 @@
     'ng2-material-dropdown': 'node_modules/ng2-material-dropdown',
     'ng2-translate': 'node_modules/ng2-translate/bundles',
     'ng2-tag-input': 'node_modules/ng2-tag-input',
-    'ng2-pagination': 'node_modules/ng2-pagination',
+    'ngx-pagination': 'node_modules/ngx-pagination',
     'js-base64': 'node_modules/js-base64/base64.js',
     'buffer': 'node_modules/buffer-shims/index.js',
     'angular2-color-picker': 'node_modules/angular2-color-picker',
@@ -59,9 +59,9 @@
       defaultExtension: 'js',
       main: 'dist/ng2-tag-input.bundle.js'
     },
-    'ng2-pagination': {
+    'ngx-pagination': {
       defaultExtension: 'js',
-      main: 'index.js'
+      main: 'dist/ngx-pagination.umd.js'
     },
     'angular2-color-picker': {
       format: 'cjs',


### PR DESCRIPTION
`Ng2-Pagination` is deprecated. The package has been renamed to `ngx-pagination` and restructured as flat ES module. This also updates the package from version **2.0.1** to **3.0.0**