### PR TITLE
HIPCMS-803: Filter mobile pages by type

### DIFF
--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
@@ -5,6 +5,12 @@
     </md-option>
   </md-select>
 
+  <md-select [(ngModel)]="selectedType" (ngModelChange)="reloadList()" placeholder="{{ 'filter by type' | translate }}">
+    <md-option *ngFor="let type of searchTypeOptions" [value]="type">
+      {{ type | translate }}
+    </md-option>
+  </md-select>
+
   <button md-mini-fab (click)="addPage()" title="{{ 'add page' | translate }}">
     <md-icon>add</md-icon>
   </button>
@@ -44,7 +50,7 @@
         </button>
       </md-list-item>
     </md-list>
-    
+
     <button md-icon-button color="primary" [disabled]="isLast" title="{{ 'move down' | translate }}" (click)="movePageDown(page)">
       <md-icon>details</md-icon>
     </button>

--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
@@ -51,10 +51,12 @@
       </md-list-item>
     </md-list>
 
-    <button md-icon-button color="primary" [disabled]="isLast" title="{{ 'move down' | translate }}" (click)="movePageDown(page)">
+    <button *ngIf="selectedStatus === 'ALL' && selectedType === 'ALL'"
+      md-icon-button color="primary" [disabled]="isLast" title="{{ 'move down' | translate }}" (click)="movePageDown(page)">
       <md-icon>details</md-icon>
     </button>
-    <button md-icon-button color="primary" [disabled]="isFirst" title="{{ 'move up' | translate }}" (click)="movePageUp(page)">
+    <button *ngIf="selectedStatus === 'ALL' && selectedType === 'ALL'"
+      md-icon-button color="primary" [disabled]="isFirst" title="{{ 'move up' | translate }}" (click)="movePageUp(page)">
       <md-icon>change_history</md-icon>
     </button>
     <button md-icon-button color="primary" [routerLink]="['/mobile-content/pages/edit', page.id]" title="{{ 'edit page' | translate }}">

--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
@@ -6,7 +6,7 @@ import { TranslateService } from 'ng2-translate';
 import { ConfirmDeleteDialogComponent } from '../../shared/confirm-delete-dialog/confirm-delete-dialog.component';
 import { EditPageComponent } from '../../pages/edit-page/edit-page.component';
 import { ExhibitService } from '../shared/exhibit.service';
-import { MobilePage } from '../../pages/shared/mobile-page.model';
+import { MobilePage, pageTypeForSearch } from '../../pages/shared/mobile-page.model';
 import { MobilePageService } from '../../pages/shared/mobile-page.service';
 import { SelectPageDialogComponent } from '../../pages/select-page-dialog/select-page-dialog.component';
 import { Status, statusTypeForSearch } from '../../shared/status.model';
@@ -22,7 +22,9 @@ export class EditExhibitPagesComponent implements OnInit {
   infoPages = new Map<number, MobilePage>();
   pages: MobilePage[];
   searchStatusOptions = Status.getValuesForSearch();
+  searchTypeOptions = ['ALL'].concat(MobilePage.pageTypeValues);
   selectedStatus: statusTypeForSearch = 'ALL';
+  selectedType: pageTypeForSearch = 'ALL';
   statusOptions = Status.getValues();
 
   private deleteDialogRef: MdDialogRef<ConfirmDeleteDialogComponent>;
@@ -106,7 +108,7 @@ export class EditExhibitPagesComponent implements OnInit {
   }
 
   reloadList() {
-    this.pageService.getAllPagesFor(this.exhibitId, this.selectedStatus)
+    this.pageService.getAllPagesFor(this.exhibitId, this.selectedStatus, this.selectedType)
       .then(
         pages => {
           this.pages = pages;

--- a/app/mobile-content/pages/shared/mobile-page.model.ts
+++ b/app/mobile-content/pages/shared/mobile-page.model.ts
@@ -1,4 +1,5 @@
 export type pageType = 'Appetizer_Page' | 'Image_Page' | 'Slider_Page' | 'Text_Page';
+export type pageTypeForSearch = 'ALL' | pageType;
 type fontFamilyOptions = 'DEFAULT' | 'AlteSchwabacher';
 type sliderImage = { date: string, image: number };
 

--- a/app/mobile-content/pages/shared/mobile-page.service.ts
+++ b/app/mobile-content/pages/shared/mobile-page.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Response } from '@angular/http';
 
-import { MobilePage } from './mobile-page.model';
+import { MobilePage, pageTypeForSearch } from './mobile-page.model';
 import { MobileContentApiService } from '../../shared/mobile-content-api.service';
 import { statusTypeForSearch } from '../../shared/status.model';
 
@@ -58,8 +58,9 @@ export class MobilePageService {
    * Retrieves all mobile pages currently stored on the server.
    * @param status Restricts results to only pages with a specific status. Defaults to 'ALL'.
    */
-  getAllPages(query = '', status: statusTypeForSearch = 'ALL'): Promise<MobilePage[]> {
+  getAllPages(query = '', status: statusTypeForSearch = 'ALL', type: pageTypeForSearch = 'ALL'): Promise<MobilePage[]> {
     let params = '?status=' + status;
+    params += type === 'ALL' ? '' : '&type=' + type;
     if (query) {
       params += '&query=' + encodeURIComponent(query);
     }

--- a/app/mobile-content/pages/shared/mobile-page.service.ts
+++ b/app/mobile-content/pages/shared/mobile-page.service.ts
@@ -78,8 +78,10 @@ export class MobilePageService {
    * @param id id of the exhibit for which to fetch pages
    * @param status Restricts results to only pages with a specific status. Defaults to 'ALL'.
    */
-  getAllPagesFor(id: number, status: statusTypeForSearch = 'ALL'): Promise<MobilePage[]> {
-    return this.mobileApiService.getUrl(`/api/Exhibits/${id}/Pages?status=${status}`)
+  getAllPagesFor(id: number, status: statusTypeForSearch = 'ALL', type: pageTypeForSearch = 'ALL'): Promise<MobilePage[]> {
+    let params = '?status=' + status;
+    params += type === 'ALL' ? '' : '&type=' + type;
+    return this.mobileApiService.getUrl(`/api/Exhibits/${id}/Pages` + params)
       .toPromise()
       .then(
         response => MobilePage.parseObjectArray(response.json().items)

--- a/app/mobile-content/pages/shared/page-list/page-list.component.css
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.css
@@ -9,8 +9,11 @@
 #page-search md-select {
   position: relative;
   top: 4px;
-  margin-left: 1em;
-  margin-right: 1em;
+  margin-left: .5em;
+}
+
+#create-page-button {
+  margin-left: 2em;
 }
 
 md-list {

--- a/app/mobile-content/pages/shared/page-list/page-list.component.html
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.html
@@ -16,7 +16,13 @@
     </md-option>
   </md-select>
 
-  <button md-mini-fab (click)="createPage()" title="{{ 'create page' | translate }}">
+  <md-select [(ngModel)]="selectedType" (ngModelChange)="reloadList()" placeholder="{{ 'filter by type' | translate }}">
+    <md-option *ngFor="let type of typeOptions" [value]="type">
+      {{ type | translate }}
+    </md-option>
+  </md-select>
+
+  <button md-mini-fab (click)="createPage()" title="{{ 'create page' | translate }}" id="create-page-button">
     <md-icon>add</md-icon>
   </button>
 </div>

--- a/app/mobile-content/pages/shared/page-list/page-list.component.ts
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.ts
@@ -6,7 +6,7 @@ import { TranslateService } from 'ng2-translate';
 import { ConfirmDeleteDialogComponent } from '../../../shared/confirm-delete-dialog/confirm-delete-dialog.component';
 import { CreatePageDialogComponent } from '../../create-page-dialog/create-page-dialog.component';
 import { EditPageComponent } from '../../edit-page/edit-page.component';
-import { MobilePage } from '../../shared/mobile-page.model';
+import { MobilePage, pageTypeForSearch } from '../../shared/mobile-page.model';
 import { MobilePageService } from '../../shared/mobile-page.service';
 import { Status, statusTypeForSearch } from '../../../shared/status.model';
 
@@ -25,8 +25,10 @@ export class PageListComponent implements OnInit {
   pages: MobilePage[];
   searchQuery = '';
   selectedStatus: statusTypeForSearch = 'ALL';
+  selectedType: pageTypeForSearch = 'ALL';
   showingSearchResults = false;
   statusOptions = Status.getValuesForSearch();
+  typeOptions = ['ALL'].concat(MobilePage.pageTypeValues);
 
   private editDialogRef: MdDialogRef<EditPageComponent>;
   private createDialogRef: MdDialogRef<CreatePageDialogComponent>;
@@ -91,7 +93,7 @@ export class PageListComponent implements OnInit {
   }
 
   reloadList() {
-    this.pageService.getAllPages(this.searchQuery, this.selectedStatus)
+    this.pageService.getAllPages(this.searchQuery, this.selectedStatus, this.selectedType)
       .then(
         pages => {
           this.pages = pages;


### PR DESCRIPTION
- Mobile pages can now be filtered by type.
- Changing the order of pages in a _filtered_ page list (of an exhibit) is disabled. Reordering a filtered list doesn't make sense in the first place and doing so completely replaces an exhibit's mobile page list with the filtered one which is not expected behavior.