### PR TITLE
HIPCMS-811: Select multiple pages at once

### DIFF
--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
@@ -11,7 +11,7 @@
     </md-option>
   </md-select>
 
-  <button md-mini-fab (click)="addPage()" title="{{ 'add page' | translate }}">
+  <button md-mini-fab (click)="addPages()" title="{{ 'add page' | translate }}">
     <md-icon>add</md-icon>
   </button>
 </div>

--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
@@ -41,26 +41,27 @@ export class EditExhibitPagesComponent implements OnInit {
     this.reloadList();
   }
 
-  addPage() {
+  addPages() {
     this.selectDialogRef = this.dialog.open(SelectPageDialogComponent, { width: '75%' });
     this.selectDialogRef.afterClosed().subscribe(
-      (selectedPage: MobilePage) => {
-        if (!selectedPage) { return; }
-        this.exhibitService.getExhibit(this.exhibitId)
-          .then(
-            exhibit => {
-              exhibit.pages.push(selectedPage.id);
-              return this.exhibitService.updateExhibit(exhibit);
-            }
-          ).then(
-            () => {
-              this.pages.push(selectedPage);
-              if (selectedPage.hasInfoPages()) { this.getInfoPages(); }
-              this.toasterService.pop('success', this.translateService.instant('page added'));
-            }
-          ).catch(
-            () => this.toasterService.pop('error', this.translateService.instant('addition failed'))
-          );
+      (selectedPages: MobilePage[]) => {
+        if (selectedPages && selectedPages.length > 0) {
+          this.exhibitService.getExhibit(this.exhibitId)
+            .then(
+              exhibit => {
+                exhibit.pages = exhibit.pages.concat(selectedPages.map(page => page.id));
+                return this.exhibitService.updateExhibit(exhibit);
+              }
+            ).then(
+              () => {
+                this.pages = this.pages.concat(selectedPages);
+                if (selectedPages.some(page => page.hasInfoPages())) { this.getInfoPages(); }
+                this.toasterService.pop('success', this.translateService.instant('page added'));
+              }
+            ).catch(
+              () => this.toasterService.pop('error', this.translateService.instant('addition failed'))
+            );
+        }
       }
     );
   }

--- a/app/mobile-content/pages/select-page-dialog/select-page-dialog.component.html
+++ b/app/mobile-content/pages/select-page-dialog/select-page-dialog.component.html
@@ -1,5 +1,16 @@
-<h1 md-dialog-title>{{ 'select page' | translate }}</h1>
+<h1 md-dialog-title>{{ 'select pages' | translate }}</h1>
 
 <md-dialog-content>
-  <hip-page-list [selectMode]="true" [excludeIds]="excludeIds" [asInfoPage]="asInfoPage" (onSelect)="selectPage($event)"></hip-page-list>
+  <hip-page-list [selectMode]="true" [excludeIds]="excludeIds" [asInfoPage]="asInfoPage" (onSelect)="selectPages($event)"></hip-page-list>
 </md-dialog-content>
+
+<md-dialog-actions align="end">
+  <button md-raised-button md-dialog-close>
+    {{ 'cancel' | translate }}
+    <md-icon>cancel</md-icon>
+  </button>
+  <button md-raised-button [md-dialog-close]="selectedPages" color="primary" [disabled]="selectedPages.length < 1">
+    {{ 'select' | translate }}
+    <md-icon>add</md-icon>
+  </button>
+</md-dialog-actions>

--- a/app/mobile-content/pages/select-page-dialog/select-page-dialog.component.ts
+++ b/app/mobile-content/pages/select-page-dialog/select-page-dialog.component.ts
@@ -12,6 +12,7 @@ import { MobilePage } from '../shared/mobile-page.model';
 export class SelectPageDialogComponent implements OnInit {
   asInfoPage = false;
   excludeIds: number[] = [];
+  selectedPages: MobilePage[] = [];
 
   constructor(public dialogRef: MdDialogRef<SelectPageDialogComponent>,
               @Inject(MD_DIALOG_DATA) public data: { asInfoPage: boolean, excludeIds: number[] }) {}
@@ -23,7 +24,7 @@ export class SelectPageDialogComponent implements OnInit {
     }
   }
 
-  selectPage(page: MobilePage) {
-    this.dialogRef.close(page);
+  selectPages(pages: MobilePage[]) {
+    this.selectedPages = pages;
   }
 }

--- a/app/mobile-content/pages/shared/page-input/page-input.component.html
+++ b/app/mobile-content/pages/shared/page-input/page-input.component.html
@@ -4,7 +4,7 @@
     <md-select placeholder="{{ 'type' | translate }}" [(ngModel)]="page.pageType" *ngIf="page.id === -1">
       <md-option *ngFor="let pageType of pageTypes" [value]="pageType">{{ pageType | translate }}</md-option>
     </md-select>
-  
+
     <!-- Title only for slider and text pages -->
     <md-input-container *ngIf="page.isSliderPage() || page.isTextPage()">
       <input mdInput placeholder="{{ 'title' | translate }}" [(ngModel)]="page.title">
@@ -65,7 +65,7 @@
 
       <md-select placeholder="{{ 'status' | translate }}" [(ngModel)]="page.status" name="status">
         <md-option *ngFor="let status of statusOptions" [value]="status">{{ status | translate }}</md-option>
-      </md-select>  
+      </md-select>
     </div>
   </div>
 
@@ -112,7 +112,7 @@
       <ng-template #noInfoPages>
         <span class="empty-set-message">({{ 'no info pages' | translate }})</span>
       </ng-template>
-      <button md-icon-button color="primary" title="{{ 'select page' | translate }}" (click)="addInfoPage()">
+      <button md-icon-button color="primary" title="{{ 'select pages' | translate }}" (click)="addInfoPages()">
         <md-icon>note_add</md-icon>
       </button>
     </div>

--- a/app/mobile-content/pages/shared/page-input/page-input.component.ts
+++ b/app/mobile-content/pages/shared/page-input/page-input.component.ts
@@ -67,7 +67,7 @@ export class PageInputComponent implements OnInit {
     }
   }
 
-  addInfoPage() {
+  addInfoPages() {
     this.selectPageDialogRef = this.dialog.open(SelectPageDialogComponent, {
       width: '75%',
       data: {
@@ -76,10 +76,11 @@ export class PageInputComponent implements OnInit {
       }
     });
     this.selectPageDialogRef.afterClosed().subscribe(
-      (selectedPage: MobilePage) => {
-        if (!selectedPage) { return; }
-        this.page.additionalInformationPages.push(selectedPage.id);
-        this.infoPages.set(selectedPage.id, selectedPage);
+      (selectedPages: MobilePage[]) => {
+        if (selectedPages && selectedPages.length > 0) {
+          this.page.additionalInformationPages = this.page.additionalInformationPages.concat(selectedPages.map(page => page.id));
+          selectedPages.forEach(page => this.infoPages.set(page.id, page));
+        }
       }
     );
   }

--- a/app/mobile-content/pages/shared/page-list/page-list.component.html
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.html
@@ -38,7 +38,8 @@
       <span [ngClass]="{'warning': !page.isPublished()}">{{ page.status | translate }}</span>
     </p>
     <p md-line>{{ page.text }}</p>
-    <button md-icon-button color="primary" [routerLink]="['/mobile-content/pages/edit', page.id]" title="{{ 'edit page' | translate }}">
+    <md-icon *ngIf="selectMode && selectedPages.includes(page)">done</md-icon>
+    <button md-icon-button color="primary" [routerLink]="['/mobile-content/pages/edit', page.id]" title="{{ 'edit page' | translate }}" *ngIf="!selectMode">
       <md-icon>edit</md-icon>
     </button>
     <button md-icon-button color="warn" (click)="deletePage(page)" title="{{ 'delete page' | translate }}" *ngIf="!selectMode">

--- a/app/mobile-content/pages/shared/page-list/page-list.component.ts
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.ts
@@ -20,10 +20,11 @@ export class PageListComponent implements OnInit {
   @Input() asInfoPage = false;
   @Input() excludeIds: number[] = [];
   @Input() selectMode = false;
-  @Output() onSelect = new EventEmitter<MobilePage>();
+  @Output() onSelect = new EventEmitter<MobilePage[]>();
 
   pages: MobilePage[];
   searchQuery = '';
+  selectedPages: MobilePage[] = [];
   selectedStatus: statusTypeForSearch = 'ALL';
   selectedType: pageTypeForSearch = 'ALL';
   showingSearchResults = false;
@@ -93,6 +94,8 @@ export class PageListComponent implements OnInit {
   }
 
   reloadList() {
+    this.selectedPages = [];
+    this.onSelect.emit(this.selectedPages);
     this.pageService.getAllPages(this.searchQuery, this.selectedStatus, this.selectedType)
       .then(
         pages => {
@@ -116,7 +119,14 @@ export class PageListComponent implements OnInit {
   }
 
   selectPage(page: MobilePage) {
-    if (!this.selectMode) { return; }
-    this.onSelect.emit(page);
+    if (this.selectMode) {
+      let pos = this.selectedPages.findIndex(p => p.id === page.id);
+      if (pos === -1) {
+        this.selectedPages.push(page);
+      } else {
+        this.selectedPages.splice(pos, 1);
+      }
+    }
+    this.onSelect.emit(this.selectedPages);
   }
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -434,7 +434,7 @@
   "no pages": "Keine Seiten gefunden",
   "no title": "kein Titel",
   "page order updated": "Seitenreihenfolge aktualisiert",
-  "select page": "Seite auswählen",
+  "select pages": "Seiten auswählen",
   "no info pages": "keine Infoseiten",
   "no slider images": "keine Slider-Bilder",
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -353,7 +353,7 @@
   "no pages": "No pages found",
   "no title": "no title",
   "page order updated": "Page order updated",
-  "select page": "Select page",
+  "select pages": "Select pages",
   "no info pages": "no additional pages",
   "no slider images": "no slider images",
 


### PR DESCRIPTION
- When adding mobile pages to exhibits or other mobile pages, it is now possible to add several pages at once.
- Fixes a bug where the button to edit a mobile page would show up during page selection.