### PR TITLE
HIPCMS-823: Previews for Mobile Pages

### DIFF
--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.css
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.css
@@ -7,6 +7,10 @@
   margin-left: 2em;
 }
 
+.type-icon {
+  color: rgba(0, 0, 0, 0.38);
+}
+
 .infopages {
   transform: scale(.9, .9);
 }

--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
@@ -20,6 +20,19 @@
 
 <md-list *ngIf="pages != null && pages.length > 0;else noPages">
   <md-list-item *ngFor="let page of pages; let idx = index; let isFirst = first; let isLast = last">
+    <img md-list-avatar *ngIf="previewsLoaded && previews.has(page.id); else pageIcon"
+      [src]="previews.get(page.id)" alt="{{ 'image preview' | translate }}"
+      [ngStyle]="{'width.px': 48, 'height.px': 48}">
+    <ng-template #pageIcon>
+      <md-icon md-list-icon class="type-icon" [ngStyle]="{'font-size.px': 40, 'height.px': 40, 'width.px': 40}">
+        {{
+          page.isTextPage() ? 'subject' :
+          page.isImagePage() ? 'photo' :
+          page.isSliderPage() ? 'photo_library' : 'phone_android'
+        }}
+      </md-icon>
+    </ng-template>
+
     <h2 md-line>{{ page.title || '(' + ('no title' | translate) + ')' }}</h2>
 
     <p md-line>
@@ -33,6 +46,19 @@
     <md-list md-line class="infopages" *ngIf="page.hasInfoPages()">
       <h3 md-subheader>{{ 'additional information pages' | translate }}:</h3>
       <md-list-item *ngFor="let infoPageId of page.additionalInformationPages; let idx = index; let isFirst = first; let isLast = last">
+        <img md-list-avatar *ngIf="previewsLoaded && previews.has(infoPageId); else pageIcon"
+          [src]="previews.get(infoPageId)" alt="{{ 'image preview' | translate }}"
+          [ngStyle]="{'width.px': 48, 'height.px': 48}">
+        <ng-template #pageIcon>
+          <md-icon md-list-icon class="type-icon" [ngStyle]="{'font-size.px': 40, 'height.px': 40, 'width.px': 40}" *ngIf="infoPages.has(infoPageId)">
+            {{
+              infoPages.get(infoPageId).isTextPage() ? 'subject' :
+              infoPages.get(infoPageId).isImagePage() ? 'photo' :
+              infoPages.get(infoPageId).isSliderPage() ? 'photo_library' : 'phone_android'
+            }}
+          </md-icon>
+        </ng-template>
+
         <h4 md-line *ngIf="infoPages.has(infoPageId)">
           {{ infoPages.get(infoPageId).title || '(' + ('no title' | translate) + ')' }}
         </h4>

--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.html
@@ -71,7 +71,7 @@
         </p>
         <p md-line *ngIf="infoPages.has(infoPageId)">{{ infoPages.get(infoPageId).text }}</p>
         <button md-icon-button color="primary" *ngIf="infoPages.has(infoPageId)"
-                (click)="editPage(infoPages.get(infoPageId))" title="{{ 'edit' | translate }}">
+                [routerLink]="['/mobile-content/pages/edit', infoPageId]" title="{{ 'edit page' | translate }}">
           <md-icon>edit</md-icon>
         </button>
       </md-list-item>

--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
@@ -161,7 +161,7 @@ export class EditExhibitPagesComponent implements OnInit {
                 reader.onloadend = () => {
                   this.previews.set(page.id, this.sanitizer.bypassSecurityTrustUrl(reader.result));
                   this.previewsLoaded = all.length === this.previews.size;
-                }
+                };
               }
             ).catch();
         }

--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
@@ -148,24 +148,30 @@ export class EditExhibitPagesComponent implements OnInit {
   }
 
   private loadPreviews() {
-    this.pages.concat(Array.from(this.infoPages.values()))
-      .filter((page, index, all) => all.findIndex(p => p.id === page.id) === index)   // filter out duplicates
-      .filter(page => page.getPreviewId() !== -1 && !this.previews.has(page.id))
-      .forEach(
-        (page, index, all) => {
-          this.mediaService.downloadFile(page.getPreviewId(), true)
-            .then(
-              response => {
-                let reader = new FileReader();
-                reader.readAsDataURL(response);
-                reader.onloadend = () => {
-                  this.previews.set(page.id, this.sanitizer.bypassSecurityTrustUrl(reader.result));
-                  this.previewsLoaded = all.length === this.previews.size;
-                };
-              }
-            ).catch();
-        }
-      );
+    let previewable = this.pages.concat(Array.from(this.infoPages.values()))
+                      .filter((page, index, all) => all.findIndex(p => p.id === page.id) === index)
+                      .filter(page => page.getPreviewId() !== -1 && !this.previews.has(page.id));
+    previewable.forEach(
+      page => {
+        this.mediaService.downloadFile(page.getPreviewId(), true)
+          .then(
+            response => {
+              let reader = new FileReader();
+              reader.readAsDataURL(response);
+              reader.onloadend = () => {
+                this.previews.set(page.id, this.sanitizer.bypassSecurityTrustUrl(reader.result));
+                this.previewsLoaded = previewable.every(p => this.previews.has(p.id));
+              };
+            }
+          ).catch(
+            error => {
+              previewable.splice(previewable.findIndex(p => p.id === page.id), 1);
+              this.previews.delete(page.id);
+              this.previewsLoaded = previewable.every(p => this.previews.has(p.id));
+            }
+          );
+      }
+    );
   }
 
   private updatePageOrder() {

--- a/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
+++ b/app/mobile-content/exhibits/edit-exhibit-pages/edit-exhibit-pages.component.ts
@@ -5,7 +5,6 @@ import { ToasterService } from 'angular2-toaster';
 import { TranslateService } from 'ng2-translate';
 
 import { ConfirmDeleteDialogComponent } from '../../shared/confirm-delete-dialog/confirm-delete-dialog.component';
-import { EditPageComponent } from '../../pages/edit-page/edit-page.component';
 import { ExhibitService } from '../shared/exhibit.service';
 import { MediaService } from '../../media/shared/media.service';
 import { MobilePage, pageTypeForSearch } from '../../pages/shared/mobile-page.model';
@@ -32,7 +31,6 @@ export class EditExhibitPagesComponent implements OnInit {
   statusOptions = Status.getValues();
 
   private deleteDialogRef: MdDialogRef<ConfirmDeleteDialogComponent>;
-  private editDialogRef: MdDialogRef<EditPageComponent>;
   private selectDialogRef: MdDialogRef<SelectPageDialogComponent>;
 
   constructor(private dialog: MdDialog,
@@ -68,32 +66,6 @@ export class EditExhibitPagesComponent implements OnInit {
               () => this.toasterService.pop('error', this.translateService.instant('addition failed'))
             );
         }
-      }
-    );
-  }
-
-  editPage(page: MobilePage) {
-    this.editDialogRef = this.dialog.open(EditPageComponent, { data: { pageToEdit: page } });
-    this.editDialogRef.afterClosed().subscribe(
-      (updatedPage: MobilePage) => {
-        if (!updatedPage) { return; }
-        this.pageService.updatePage(updatedPage)
-          .then(
-            () => {
-              if (this.pages.indexOf(page) > -1) {
-                this.pages[this.pages.indexOf(page)] = updatedPage;
-                this.getInfoPages();
-              }
-
-              if (this.infoPages.has(page.id)) {
-                this.infoPages.set(page.id, updatedPage);
-              }
-
-              this.toasterService.pop('success', this.translateService.instant('page updated'));
-            }
-          ).catch(
-            () => this.toasterService.pop('error', this.translateService.instant('update failed'))
-          );
       }
     );
   }

--- a/app/mobile-content/pages/shared/mobile-page.model.ts
+++ b/app/mobile-content/pages/shared/mobile-page.model.ts
@@ -83,6 +83,16 @@ export class MobilePage {
     return pages;
   }
 
+  getPreviewId(): number {
+    let previewId = -1;
+    if (this.image != null) {
+      previewId = this.image;
+    } else if (this.images && this.images.length > 0) {
+      previewId = this.images[0].image;
+    }
+    return previewId;
+  }
+
   hasInfoPages(): boolean {
     return this.additionalInformationPages && this.additionalInformationPages.length > 0;
   }

--- a/app/mobile-content/pages/shared/page-list/page-list.component.css
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.css
@@ -25,6 +25,18 @@ md-list-item {
   width: 50%;
 }
 
+md-list-item button {
+  display: none;
+}
+
+md-list-item:hover button {
+  display: initial;
+}
+
+.type-icon {
+  color: rgba(0, 0, 0, 0.38);
+}
+
 .clickable:hover {
   cursor: pointer;
   background-color: rgba(50, 50, 50, .1);

--- a/app/mobile-content/pages/shared/page-list/page-list.component.html
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.html
@@ -31,6 +31,19 @@
 
 <md-list *ngIf="pages != null && pages.length > 0;else noPages">
   <md-list-item *ngFor="let page of pages" (click)="selectPage(page)" [ngClass]="{'clickable': selectMode}">
+    <img md-list-avatar *ngIf="previewsLoaded && previews.has(page.id); else pageIcon"
+      [src]="previews.get(page.id)" alt="{{ 'image preview' | translate }}"
+      [ngStyle]="{'width.px': 48, 'height.px': 48}">
+    <ng-template #pageIcon>
+      <md-icon md-list-icon class="type-icon" [ngStyle]="{'font-size.px': 40, 'height.px': 40, 'width.px': 40}">
+        {{
+          page.isTextPage() ? 'subject' :
+          page.isImagePage() ? 'photo' :
+          page.isSliderPage() ? 'photo_library' : 'phone_android'
+        }}
+      </md-icon>
+    </ng-template>
+
     <h3 md-line>{{ page.title || '(' + ('no title' | translate) + ')' }}</h3>
     <p md-line>
       <span>{{ page.pageType | translate }}</span>
@@ -38,7 +51,8 @@
       <span [ngClass]="{'warning': !page.isPublished()}">{{ page.status | translate }}</span>
     </p>
     <p md-line>{{ page.text }}</p>
-    <md-icon *ngIf="selectMode && selectedPages.includes(page)">done</md-icon>
+
+    <md-icon *ngIf="selectMode && selectedPages.includes(page)" color="accent">done</md-icon>
     <button md-icon-button color="primary" [routerLink]="['/mobile-content/pages/edit', page.id]" title="{{ 'edit page' | translate }}" *ngIf="!selectMode">
       <md-icon>edit</md-icon>
     </button>

--- a/app/mobile-content/pages/shared/page-list/page-list.component.ts
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.ts
@@ -1,11 +1,13 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MdDialog, MdDialogRef } from '@angular/material';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { ToasterService } from 'angular2-toaster';
 import { TranslateService } from 'ng2-translate';
 
 import { ConfirmDeleteDialogComponent } from '../../../shared/confirm-delete-dialog/confirm-delete-dialog.component';
 import { CreatePageDialogComponent } from '../../create-page-dialog/create-page-dialog.component';
 import { EditPageComponent } from '../../edit-page/edit-page.component';
+import { MediaService } from '../../../media/shared/media.service';
 import { MobilePage, pageTypeForSearch } from '../../shared/mobile-page.model';
 import { MobilePageService } from '../../shared/mobile-page.service';
 import { Status, statusTypeForSearch } from '../../../shared/status.model';
@@ -23,6 +25,8 @@ export class PageListComponent implements OnInit {
   @Output() onSelect = new EventEmitter<MobilePage[]>();
 
   pages: MobilePage[];
+  previews = new Map<number, SafeUrl>();
+  previewsLoaded = false;
   searchQuery = '';
   selectedPages: MobilePage[] = [];
   selectedStatus: statusTypeForSearch = 'ALL';
@@ -36,7 +40,9 @@ export class PageListComponent implements OnInit {
   private deleteDialogRef: MdDialogRef<ConfirmDeleteDialogComponent>;
 
   constructor(private dialog: MdDialog,
+              private mediaService: MediaService,
               private pageService: MobilePageService,
+              private sanitizer: DomSanitizer,
               private toasterService: ToasterService,
               private translateService: TranslateService) {}
 
@@ -100,6 +106,7 @@ export class PageListComponent implements OnInit {
       .then(
         pages => {
           this.pages = pages;
+          this.loadPreviews();
 
           if (this.selectMode && this.excludeIds.length > 0) {
             this.pages = this.pages.filter(page => !this.excludeIds.includes(page.id));
@@ -128,5 +135,24 @@ export class PageListComponent implements OnInit {
       }
     }
     this.onSelect.emit(this.selectedPages);
+  }
+
+  private loadPreviews() {
+    this.pages.filter(page => page.getPreviewId() !== -1 && !this.previews.has(page.id))
+      .forEach(
+        (page, index, all) => {
+          this.mediaService.downloadFile(page.getPreviewId(), true)
+            .then(
+              response => {
+                let reader = new FileReader();
+                reader.readAsDataURL(response);
+                reader.onloadend = () => {
+                  this.previews.set(page.id, this.sanitizer.bypassSecurityTrustUrl(reader.result));
+                  this.previewsLoaded = all.length === this.previews.size;
+                }
+              }
+            ).catch();
+        }
+      );
   }
 }

--- a/app/mobile-content/pages/shared/page-list/page-list.component.ts
+++ b/app/mobile-content/pages/shared/page-list/page-list.component.ts
@@ -149,7 +149,7 @@ export class PageListComponent implements OnInit {
                 reader.onloadend = () => {
                   this.previews.set(page.id, this.sanitizer.bypassSecurityTrustUrl(reader.result));
                   this.previewsLoaded = all.length === this.previews.size;
-                }
+                };
               }
             ).catch();
         }


### PR DESCRIPTION
**Changes**
- Mobile pages show a preview both on the overview page and in the list of pages attached to an exhibit.
    - If a page has an attached image, the image will be used for preview.
    - Slider pages will show first slideshow image as preview.
    - If none of the above is present, a type-specific icon will be displayed.
- In the pages overview component, the buttons to edit or delete a page are displayed only on mouse hover.
- When selecting pages, the checkmark icon is displayed in accent color.

**Bugfixes**
- Trying to edit an information page in the list of exhibit's attached pages causes an error, instead of loading the "edit page" component.
- Removed leftover code which is not needed now that page editor is not a dialog.