### PR TITLE
HIPCMS-825: Load Media Previews Simultaneously

### DIFF
--- a/app/mobile-content/media/media-gallery/media-gallery.component.css
+++ b/app/mobile-content/media/media-gallery/media-gallery.component.css
@@ -30,6 +30,14 @@ md-list-item {
   color: rgba(0, 0, 0, 0.38);
 }
 
+md-list-item button {
+  display: none;
+}
+
+md-list-item:hover button {
+  display: initial;
+}
+
 .clickable:hover {
   cursor: pointer;
   background-color: rgba(50, 50, 50, .1);

--- a/app/mobile-content/media/media-gallery/media-gallery.component.html
+++ b/app/mobile-content/media/media-gallery/media-gallery.component.html
@@ -36,9 +36,10 @@
 
 
     <img md-list-avatar *ngIf="previewsLoaded && previews.has(medium.id); else mediaIcon"
-         [src]="previews.get(medium.id)" alt="{{ 'image preview' | translate }}">
+         [src]="previews.get(medium.id)" alt="{{ 'image preview' | translate }}"
+         [ngStyle]="{'width.px': 48, 'height.px': 48}">
     <ng-template #mediaIcon>
-      <md-icon md-list-icon class="type-icon">
+      <md-icon md-list-icon class="type-icon" [ngStyle]="{'font-size.px': 40, 'height.px': 40, 'width.px': 40}">
         {{ medium.isAudio() ? 'audiotrack' : 'photo' }}
       </md-icon>
     </ng-template>

--- a/app/mobile-content/media/media-gallery/media-gallery.component.html
+++ b/app/mobile-content/media/media-gallery/media-gallery.component.html
@@ -35,10 +35,13 @@
                                                           totalItems: totalItems }">
 
 
-    <md-icon md-list-icon class="type-icon" *ngIf="!previews.has(medium.id)">
-      {{ medium.isAudio() ? 'audiotrack' : 'camera' }}
-    </md-icon>
-    <img md-list-avatar *ngIf="previews.has(medium.id)" [src]="previews.get(medium.id)" alt="{{ 'image preview' | translate }}">
+    <img md-list-avatar *ngIf="previewsLoaded && previews.has(medium.id); else mediaIcon"
+         [src]="previews.get(medium.id)" alt="{{ 'image preview' | translate }}">
+    <ng-template #mediaIcon>
+      <md-icon md-list-icon class="type-icon">
+        {{ medium.isAudio() ? 'audiotrack' : 'photo' }}
+      </md-icon>
+    </ng-template>
 
     <h3 md-line>{{ medium.title }}</h3>
 

--- a/app/mobile-content/media/media-gallery/media-gallery.component.ts
+++ b/app/mobile-content/media/media-gallery/media-gallery.component.ts
@@ -196,14 +196,14 @@ export class MediaGalleryComponent implements OnInit {
               reader.readAsDataURL(response);
               reader.onloadend = () => {
                 this.previews.set(medium.id, this.sanitizer.bypassSecurityTrustUrl(reader.result));
-                this.previewsLoaded = previewable.every(medium => this.previews.has(medium.id));
+                this.previewsLoaded = previewable.every(m => this.previews.has(m.id));
               };
             }
           ).catch(
             error => {
               previewable.splice(previewable.findIndex(m => m.id === medium.id), 1);
               this.previews.delete(medium.id);
-              this.previewsLoaded = previewable.every(medium => this.previews.has(medium.id));
+              this.previewsLoaded = previewable.every(m => this.previews.has(m.id));
             }
           );
       }


### PR DESCRIPTION
**Changes**
- Previews in the media gallery are now displayed at once, instead of loading one by one.
- Previews are now larger.
- List items with a preview and items with a type icon are now vertically aligned.
- Buttons to edit or delete a medium now only appear on mouse hover.

**Bugfixes**
- Fixed a bug where no previews would be displayed at all if even one of them fails to load. 