### PR TITLE
HIPCMS-824: Previews & Improvements for Exhibits Component

### DIFF
--- a/app/mobile-content/exhibits/exhibits.component.css
+++ b/app/mobile-content/exhibits/exhibits.component.css
@@ -8,7 +8,7 @@
 
 #exhibit-search md-select {
   position: relative;
-  top: -5px;
+  top: 4px;
   margin-left: .5em;
 }
 
@@ -26,4 +26,11 @@
 
 .type-icon {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.tag-name {
+  margin-right: 1em;
+  background: #dddddd;
+  border-radius: 16px;
+  padding: .5em;
 }

--- a/app/mobile-content/exhibits/exhibits.component.css
+++ b/app/mobile-content/exhibits/exhibits.component.css
@@ -23,3 +23,7 @@
 .latitude::after, .longitude::after {
   content: '°';
 }
+
+.type-icon {
+  color: rgba(0, 0, 0, 0.38);
+}

--- a/app/mobile-content/exhibits/exhibits.component.html
+++ b/app/mobile-content/exhibits/exhibits.component.html
@@ -38,6 +38,13 @@
                                                                 itemsPerPage: exhibitsPerPage,
                                                                 currentPage: currentPage,
                                                                 totalItems: totalItems }">
+
+      <img md-list-avatar *ngIf="previewsLoaded && previews.has(exhibit.id); else exhibitIcon"
+        [src]="previews.get(exhibit.id)" alt="{{ 'image preview' | translate }}"
+        [ngStyle]="{'width.px': 48, 'height.px': 48}">
+      <ng-template #exhibitIcon>
+        <md-icon md-list-icon class="type-icon" [ngStyle]="{'font-size.px': 40, 'height.px': 40, 'width.px': 40}">place</md-icon>
+      </ng-template>
       <h2 md-line>{{ exhibit.name }} ({{ exhibit.status | translate }})</h2>
       <p md-line>{{ exhibit.description }}</p>
       <p md-line>

--- a/app/mobile-content/exhibits/exhibits.component.html
+++ b/app/mobile-content/exhibits/exhibits.component.html
@@ -22,7 +22,6 @@
     </md-select>
 
     <md-select [(ngModel)]="selectedRoute" (ngModelChange)="selectRoute()" placeholder="{{ 'filter by route' | translate }}">
-      <md-option>{{'All' | translate }}</md-option>
       <md-option *ngFor="let route of routes" [value]="route.id">
         {{ route.title | translate }}
       </md-option>
@@ -52,8 +51,7 @@
         <span class="longitude">{{ exhibit.longitude }}</span>
       </p>
       <p *ngIf="exhibit.tags.length > 0" md-line>
-        {{ 'tagged with' | translate }}:
-        <span *ngFor="let tag of exhibit.tags; let last = last">{{ tag }}<span *ngIf="!last">, </span></span>
+        <span *ngFor="let tag of exhibit.tags" class="tag-name">{{ tag }}</span>
       </p>
 
       <button md-icon-button color="primary" [routerLink]="['/mobile-content/exhibits/edit', exhibit.id]" title="{{ 'edit' | translate }}">

--- a/app/mobile-content/exhibits/exhibits.component.html
+++ b/app/mobile-content/exhibits/exhibits.component.html
@@ -21,7 +21,7 @@
       </md-option>
     </md-select>
 
-    <md-select [(ngModel)]="selectedRoute" (ngModelChange)="selectRoute()" placeholder="{{ 'filter by route' | translate }}">
+    <md-select [(ngModel)]="selectedRoute" (ngModelChange)="reloadList()" placeholder="{{ 'filter by route' | translate }}">
       <md-option *ngFor="let route of routes" [value]="route.id">
         {{ route.title | translate }}
       </md-option>

--- a/app/mobile-content/exhibits/exhibits.component.ts
+++ b/app/mobile-content/exhibits/exhibits.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MdDialog, MdDialogRef } from '@angular/material';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { ToasterService } from 'angular2-toaster';
 import { TranslateService } from 'ng2-translate';
@@ -8,6 +9,7 @@ import { ConfirmDeleteDialogComponent } from '../shared/confirm-delete-dialog/co
 import { CreateExhibitDialogComponent } from './create-exhibit-dialog/create-exhibit-dialog.component';
 import { ExhibitService } from './shared/exhibit.service';
 import { Exhibit } from './shared/exhibit.model';
+import { MediaService } from '../media/shared/media.service';
 import { Route } from '../routes/shared/route.model';
 import { RouteService } from '../routes/shared/routes.service';
 import { Status } from '../shared/status.model';
@@ -23,6 +25,9 @@ import { TagService } from '../tags/shared/tag.service';
 
 export class ExhibitsComponent implements OnInit {
   exhibits: Exhibit[];
+  existingTags: Tag[];
+  previews = new Map<number, SafeUrl>();
+  previewsLoaded = false;
   routes: Route[];
   statuses = Status.getValuesForSearch();
   private exhibitCache = new Map<number, Exhibit[]>();
@@ -33,7 +38,6 @@ export class ExhibitsComponent implements OnInit {
   selectedRoute: string;
   selectedRouteQuery: string;
   showingSearchResults = false;
-  existingTags: Tag[];
 
   // pagination parameters
   exhibitsPerPage = 10;
@@ -46,8 +50,10 @@ export class ExhibitsComponent implements OnInit {
 
   constructor(private dialog: MdDialog,
               private exhibitService: ExhibitService,
+              private mediaService: MediaService,
               public  router: Router,
               private routeService: RouteService,
+              private sanitizer: DomSanitizer,
               private tagService: TagService,
               private toasterService: ToasterService,
               private translateService: TranslateService) {}
@@ -134,7 +140,7 @@ export class ExhibitsComponent implements OnInit {
       this.currentPage = page;
     } else {
       this.exhibitService.getAllExhibits(page, this.exhibitsPerPage, this.selectedStatus,
-      this.searchQuery, 'id', undefined, this.selectedRouteQuery)
+                                         this.searchQuery, 'id', undefined, this.selectedRouteQuery)
         .then(
           data => {
             this.exhibits = data.items;
@@ -142,6 +148,7 @@ export class ExhibitsComponent implements OnInit {
             this.currentPage = page;
             this.exhibitCache.set(this.currentPage, this.exhibits);
             this.getTagNames();
+            this.loadPreviews();
           }
         ).catch(
           error => console.error(error)
@@ -197,6 +204,31 @@ export class ExhibitsComponent implements OnInit {
     this.exhibitCache.clear();
     this.getPage(1);
     this.showingSearchResults = false;
+  }
+
+  private loadPreviews() {
+    let previewable = this.exhibits.filter(exhibit => exhibit.image != null && !this.previews.has(exhibit.id));
+    previewable.forEach(
+      exhibit => {
+        this.mediaService.downloadFile(exhibit.image, true)
+          .then(
+            response => {
+              let reader = new FileReader();
+              reader.readAsDataURL(response);
+              reader.onloadend = () => {
+                this.previews.set(exhibit.id, this.sanitizer.bypassSecurityTrustUrl(reader.result));
+                this.previewsLoaded = previewable.every(ex => this.previews.has(ex.id));
+              };
+            }
+          ).catch(
+            error => {
+              previewable.splice(previewable.findIndex(ex => ex.id === exhibit.id), 1);
+              this.previews.delete(exhibit.id);
+              this.previewsLoaded = previewable.every(ex => this.previews.has(ex.id));
+            }
+          );
+      }
+    );
   }
 
   private translate(data: string): string {

--- a/app/mobile-content/exhibits/exhibits.component.ts
+++ b/app/mobile-content/exhibits/exhibits.component.ts
@@ -138,7 +138,8 @@ export class ExhibitsComponent implements OnInit {
       this.currentPage = page;
     } else {
       this.exhibitService.getAllExhibits(page, this.exhibitsPerPage, this.selectedStatus,
-                                         this.searchQuery, 'id', undefined, this.selectedRouteQuery)
+                                         this.searchQuery, 'id', undefined,
+                                         this.selectedRoute !== -1 ? [this.selectedRoute] : undefined)
         .then(
           data => {
             this.exhibits = data.items;

--- a/app/mobile-content/exhibits/exhibits.component.ts
+++ b/app/mobile-content/exhibits/exhibits.component.ts
@@ -35,8 +35,8 @@ export class ExhibitsComponent implements OnInit {
   // search parameters
   searchQuery = '';
   selectedStatus = 'ALL';
-  selectedRoute: string;
-  selectedRouteQuery: string;
+  selectedRoute = -1;
+  selectedRouteQuery = '';
   showingSearchResults = false;
 
   // pagination parameters
@@ -59,8 +59,18 @@ export class ExhibitsComponent implements OnInit {
               private translateService: TranslateService) {}
 
   ngOnInit() {
+    let allRoutesOption = Route.emptyRoute();
+    allRoutesOption.title = 'ALL';
+    this.routes = [allRoutesOption];
+
+    this.routeService.getAllRoutes(1, 100)
+    .then(
+      data => this.routes = this.routes.concat(data.items)
+    ).catch(
+      error => console.error(error)
+    );
+
     this.getPage(1);
-    this.getRoutes();
   }
 
   createExhibit() {
@@ -89,8 +99,8 @@ export class ExhibitsComponent implements OnInit {
   }
 
   selectRoute() {
-    if (!this.selectedRoute) {
-      this.selectedRouteQuery = null;
+    if (this.selectedRoute === -1) {
+      this.selectedRouteQuery = undefined;
     } else {
       this.selectedRouteQuery = '&OnlyRoutes=' + this.selectedRoute;
     }
@@ -120,18 +130,6 @@ export class ExhibitsComponent implements OnInit {
       error => this.toasterService.pop('error', this.translate('Error while saving'), error)
     );
 
-  }
-
-  getRoutes() {
-    this.routeService.getAllRoutes(1, 100, 'ALL', '')
-      .then(
-        data => {
-          this.routes = data.items;
-          this.totalItems = data.total;
-        }
-      ).catch(
-      error => console.error(error)
-    );
   }
 
   getPage(page: number) {

--- a/app/mobile-content/exhibits/exhibits.component.ts
+++ b/app/mobile-content/exhibits/exhibits.component.ts
@@ -36,7 +36,6 @@ export class ExhibitsComponent implements OnInit {
   searchQuery = '';
   selectedStatus = 'ALL';
   selectedRoute = -1;
-  selectedRouteQuery = '';
   showingSearchResults = false;
 
   // pagination parameters
@@ -96,15 +95,6 @@ export class ExhibitsComponent implements OnInit {
         this.createDialogRef = null;
       }
     );
-  }
-
-  selectRoute() {
-    if (this.selectedRoute === -1) {
-      this.selectedRouteQuery = undefined;
-    } else {
-      this.selectedRouteQuery = '&OnlyRoutes=' + this.selectedRoute;
-    }
-    this.reloadList();
   }
 
   getTagNames() {

--- a/app/mobile-content/exhibits/shared/exhibit.service.ts
+++ b/app/mobile-content/exhibits/shared/exhibit.service.ts
@@ -56,19 +56,20 @@ export class ExhibitService {
    * @param query Additional query to look for in topic title and description.
    * @param orderBy query to bring ordered array according to a particular column.
    * @param status Only return exhibits with specified status.
-   * @param includeArray the ids of the exhibits to include in the response
-   * @param includeOnlyRoute id of the selected route in the filter
+   * @param includeOnly array of exhibit ids to retrieve
+   * @param onlyInRoutes array of route ids that an exhibit has to be part of
    */
   getAllExhibits(page: number, pageSize: number, status = 'ALL', query = '', orderBy = 'id',
-                 includeArray?: string, includeOnlyRoute?: string) {
+                 includeOnly: number[] = [], onlyInRoutes: number[] = []) {
     let searchParams = '';
     searchParams += '?Page=' + page +
       '&PageSize=' + pageSize +
       '&OrderBy=' + orderBy +
       '&Status=' + status +
-      (includeOnlyRoute ? includeOnlyRoute : '') +
-      (includeArray ? includeArray : '&query=' + query)
-      ;
+      '&Query=' + query +
+      includeOnly.reduce((prev, curr) => prev + '&IncludeOnly=' + curr, '') +
+      onlyInRoutes.reduce((prev, curr) => prev + '&OnlyRoutes=' + curr, '');
+
     return this.mobileContentApiService.getUrl('/api/Exhibits' + searchParams, {})
       .toPromise()
       .then(

--- a/app/mobile-content/exhibits/shared/exhibit.service.ts
+++ b/app/mobile-content/exhibits/shared/exhibit.service.ts
@@ -66,7 +66,7 @@ export class ExhibitService {
       '&PageSize=' + pageSize +
       '&OrderBy=' + orderBy +
       '&Status=' + status +
-      '&Query=' + query +
+      '&Query=' + encodeURIComponent(query) +
       includeOnly.reduce((prev, curr) => prev + '&IncludeOnly=' + curr, '') +
       onlyInRoutes.reduce((prev, curr) => prev + '&OnlyRoutes=' + curr, '');
 

--- a/app/mobile-content/routes/edit-route/edit-route.component.ts
+++ b/app/mobile-content/routes/edit-route/edit-route.component.ts
@@ -214,11 +214,7 @@ export class EditRouteComponent implements OnInit {
 
   getExhibitNames() {
     if (this.route.exhibits) {
-      let exhibitArray = '';
-      for (let i = 0; i < this.route.exhibits.length; i++) {
-        exhibitArray = exhibitArray + '&IncludeOnly=' + this.route.exhibits[i] + '&';
-      }
-      this.exhibitService.getAllExhibits(1, 100, 'All', '', 'id', exhibitArray)
+      this.exhibitService.getAllExhibits(1, 100, 'All', '', 'id', this.route.exhibits)
         .then(
           response => {
             if (response.items) {


### PR DESCRIPTION
**Changes**
- Exhibit list component now has previews and icons.
- Tags are displayed similarly to ngx-chips.

**Bugfixes**
- Fixed misaligned selector fields.
- Fixed placeholder for "Filter by routes" not floating.
- Some code parts have been simplified.
- Re-implemented filtering results when calling `getAllExhibits()`
    - Previous implementation violated encapsulation principle: components calling the method had to construct their own URL search string instead of simply passing parameters to the method. Components that consume the service have no business knowing what the underlying URL search string should look like.
    - `Query` and `IncludeOnly` parameters were mutually exclusive for some reason.
    - Method parameters did not seamlessly conform to server's API spec (used concatenated query strings instead of arrays of exhibit/route ids).