### PR TITLE
Hide buttons for user administration and feature toggles for students

### DIFF
--- a/app/app.component.html
+++ b/app/app.component.html
@@ -131,7 +131,7 @@
           {{ 'invite users' | translate }}
         </a>
       </md-list-item>
-      <md-list-item [ngClass]="url=='/users/students' ? 'activeMenu' : ''" (click)="toggle(start)" [routerLink]="['/users/students']" *ngIf="canCreate">
+      <md-list-item [ngClass]="url=='/users/students' ? 'activeMenu' : ''" (click)="toggle(start)" [routerLink]="['/users/students']" *ngIf="canCreate && canAdmin">
         <a>
           <md-icon>people_outline</md-icon>
           {{ 'all students' | translate }}

--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -160,7 +160,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
     Promise.all([this.userService.currentUserCanAdminister()])
       .then(
         (response: any) => {
-          this.canAdmin = response;
+          this.canAdmin = response[0];
         }
       ).catch(
       (error: any) => console.error('Failed to load permissions: ' + error.error)


### PR DESCRIPTION
fixed the canAdmin value by giving the first element of response array to it, so the 'Feature Toggles' and 'User Administration' buttons are hidden for students.

added the canAdmin property to md-list-item for making the 'All Students' button hidden for the students.